### PR TITLE
link ethash-cuda against libcudart.so

### DIFF
--- a/libethash-cuda/CMakeLists.txt
+++ b/libethash-cuda/CMakeLists.txt
@@ -50,7 +50,7 @@ cuda_add_library(ethash-cuda STATIC ${sources} ${headers})
 add_dependencies(ethash-cuda cuda_kernel)
 # Cmake doesn't handle nvrtc automatically
 find_library(CUDA_nvrtc_LIBRARY NAMES nvrtc PATHS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib/x64 lib64/stubs lib/x64/stubs lib NO_DEFAULT_PATH)
-find_library(CUDA_cuda_LIBRARY NAMES cuda PATHS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib/x64 lib64/stubs lib/x64/stubs lib NO_DEFAULT_PATH)
+find_library(CUDA_cuda_LIBRARY REQUIRED NAMES cudart PATHS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib/x64 lib64/stubs lib/x64/stubs lib NO_DEFAULT_PATH)
 target_link_libraries(ethash-cuda ethcore ethash progpow Boost::thread)
 target_link_libraries(ethash-cuda ${CUDA_nvrtc_LIBRARY} ${CUDA_cuda_LIBRARY})
 target_include_directories(ethash-cuda PUBLIC ${CUDA_INCLUDE_DIRS})


### PR DESCRIPTION
fix: Could not find CUDA_cuda_LIBRARY using the following names: cuda

see also https://stackoverflow.com/questions/27018340/cmake-does-not-properly-find-cuda-library

also: cuda is required for the cmake target ethash-cuda